### PR TITLE
Filter out non-Grimoire directories

### DIFF
--- a/src/grimoire/api/fs/read.clj
+++ b/src/grimoire/api/fs/read.clj
@@ -23,7 +23,8 @@
     (if (.isDirectory handle)
       (succeed
        (for [d     (.listFiles handle)
-             :when (.isDirectory d)]
+             :when (.isDirectory d)
+             :when (.exists (io/file d "meta.edn"))]
          (t/->Group (url/url-decode (f->name d)))))
       (fail "Could not find store directory"))))
 


### PR DESCRIPTION
This addresses issue #20.

Solve it in the shortest way possible by just inserting a check whether
a directory at the group level contains a file named meta.edn. If it
doesn't, it either isn't a Grimoire directory or violates the contract
(which I can't find right now), so throw it out.

Not sure if a more complete solution is desired. – Putting the raw
string "meta.edn" in there is not so nice and maybe we should also check
directories below group level? Anyway, this commit does fix the most
common issue.