### PR TITLE
Add default reader function

### DIFF
--- a/src/grimoire/api/fs/read.clj
+++ b/src/grimoire/api/fs/read.clj
@@ -10,7 +10,6 @@
             [grimoire.api.fs.impl :as impl]
             [clojure.java.io :as io]
             [clojure.string :as string]
-            [clojure.edn :as edn]
             [cemerick.url :as url]))
 
 (defn- f->name [^java.io.File f]
@@ -178,7 +177,7 @@
       (-> handle
           slurp
           (string/replace #"#<.*?>" "nil") ;; FIXME: Hack to ignore unreadable #<>s
-          edn/read-string
+          util/edn-read-string-with-readers
           succeed)
       (fail (str "No meta for object "
                  (t/thing->path thing))))))

--- a/src/grimoire/api/web/read.clj
+++ b/src/grimoire/api/web/read.clj
@@ -16,8 +16,7 @@
             [grimoire.util :as u]
             [grimoire.either :refer [with-result succeed? result succeed fail either?]]
             [grimoire.things :as t]
-            [grimoire.api.web :as web]
-            [clojure.edn :as edn]))
+            [grimoire.api.web :as web]))
 
 ;; Interacting with the datastore - reading
 ;;--------------------------------------------------------------------
@@ -44,7 +43,7 @@
   [config thing op]
   {:post [(either? %)]}
   (let [res-string (web/make-api-url config thing op)
-        ?res       (-> res-string slurp edn/read-string)]
+        ?res       (-> res-string slurp u/edn-read-string-with-readers)]
     ((if (grim-succeed? ?res)
        succeed fail)
      (grim-result ?res))))

--- a/src/grimoire/util.clj
+++ b/src/grimoire/util.clj
@@ -3,6 +3,7 @@
   operations."
   (:refer-clojure :exclude [munge])
   (:require [clojure.string :as str]
+            [clojure.edn :as edn]
             [cemerick.url :refer [url-encode]]))
 
 (defn munge
@@ -83,3 +84,13 @@
                             [x nil])
                           ["zfinal" nil])]
     [(to-long major) (to-long minor) (to-long incremental) qual1 qual2]))
+
+(defn edn-read-string-with-readers
+  "Read a string with clojure.edn/read-string and additional reader functions
+  installed.
+
+  Currently the only additional reader function is the default reader function,
+  which will return a tuple [:cant-read <tag symbol> <raw value>]."
+  [s]
+  (edn/read-string {:default (fn [t v] [:cant-read t v])}
+                   s))


### PR DESCRIPTION
In these modern times, strange Clojure objects aren't printed as

Add a function delegating to clojure.edn/read-string primed with a
default reader function to grimoire.util. Substitute the calls to
clojure.edn/read-string with calls to that function so that unknown tags
don't cause exceptions, but result in a marker data structure.

I'm not sure if this is a good implementation. – The choice of the
marker data structure is quite arbitrary and I'm not content with where
I put the new function, but I don't know a more sensible place either.