### PR TITLE
Start working on a v2 filesystem driver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,8 @@
   :description "A shared library for Grimoire infrastructure"
   :url "http://github.com/clojure-grimoire/lib-grimoire"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [me.arrdem/guten-tag "0.1.6"
                   :exclusions [org.clojure/clojure]]
                  [org.clojure/core.match "0.3.0-alpha4"

--- a/src/grimoire/api/fs.clj
+++ b/src/grimoire/api/fs.clj
@@ -2,11 +2,16 @@
   (:require [guten-tag.core :refer [deftag]]))
 
 (deftag Config
-  "A configuration for the filesystem backend. Stores base paths for
-  docs, notes and the examples."
+  "A configuration for the filesystem back-end.
+
+  Stores base paths for docs, notes and the examples."
   [docs
    notes
    examples]
   {:pre [(string? docs)
          (string? notes)
          (string? examples)]})
+
+;; Load implementation details
+(load "fs/read")
+(load "fs/write")

--- a/src/grimoire/api/fs/impl.clj
+++ b/src/grimoire/api/fs/impl.clj
@@ -2,14 +2,10 @@
   "Filesystem datastore implementation details. This namespace is not part of
   the intentional API exposed in `grimoire.api` and should not be used by
   library client code."
-  (:require [grimoire.util :as util]
+  (:require [grimoire.util :as util :refer [file?]]
             [grimoire.things :as t]
             [grimoire.api.fs :refer [Config?]]
             [clojure.java.io :as io]))
-
-(defn file?
-  [h]
-  (instance? java.io.File h))
 
 ;; Private helpers for getting fs handles
 ;;--------------------
@@ -30,7 +26,7 @@
           (Config? cfg)]
    :post [(file? %)]}
   (let [d (get cfg ({:meta     :docs
-                     :else     :docs     ;; FIXME: is this really the default case? seems janky.
+                     :else     :docs ;; FIXME: is this really the default case? seems janky.
                      :related  :notes
                      :notes    :notes
                      :examples :examples}

--- a/src/grimoire/api/fs2.clj
+++ b/src/grimoire/api/fs2.clj
@@ -1,0 +1,25 @@
+(ns grimoire.api.fs2
+  "Filesystem v2 datastore.
+
+  Unlike the v1 file system back end which hard codes various
+  expectations about the number, structure and location of certain
+  Things, the v2 file system back end is designed to provide more
+  general applicability in the face of clients such as clj-doc and
+  stacks.
+
+  Specifically, notes and examples are fully supported in one-to-many
+  relationships with every Thing in the hierarchy."
+  (:require [grimoire.util :refer [file?]]
+            [guten-tag.core :refer [deftag]]))
+
+(deftag Config
+  "A configuration for the filesystem v2 back-end.
+
+  Stores base paths for docs, notes and the examples."
+  [root]
+  {:pre [(file? root)]})
+
+;; Load implementation details
+(load "fs2/impl")
+(load "fs2/read")
+(load "fs2/write")

--- a/src/grimoire/api/fs2/impl.clj
+++ b/src/grimoire/api/fs2/impl.clj
@@ -1,0 +1,71 @@
+(ns grimoire.api.fs2.impl
+  "Filesystem v2 datastore implementation details.
+
+  This namespace is not part of
+  the intentional API exposed in `grimoire.api` and should not be used by
+  library client code.
+
+  The desired directory tree is as follows:
+
+  ```
+  /<root>
+   /<group>
+    /meta.edn
+    /attachments
+      /notes
+      /examples
+      /related.edn
+    /children/
+      /<artifact>
+        /meta.edn
+        /attachments
+          /notes
+          /examples
+          /related.edn
+        /children
+          /<version>
+  ...
+  ```
+
+  The intent of this structure is to disambiguate between the
+  children (Things) under a Thing, and the notes/examples/metadata
+  attached to that particular node. This allows us to retain the
+  original file system backend's simplicity in listing and adding to
+  the store, while generalizing the attachment of structures such as
+  notes and examples to nodes in the hierarchy." 
+  (:require [clojure.java.io :as io]
+            [clojure.core.match :refer [match]] 
+            [grimoire.util :as util :refer [file?]]
+            [grimoire.things :as t] 
+            [grimoire.api.fs2 :refer [Config?]]
+            [guten-tag.core :refer [tag]]))
+
+(defn thing->handle
+  [{:keys [root] :as config} thing]
+  {:pre [(Config? config)
+         (t/thing? thing)]}
+  (let [parent-thing (if (t/leaf? thing)
+                       (:parent thing)
+                       thing)
+        components   (->> (iterate :parent parent-thing)
+                          (take-while (complement nil?))
+                          (map :name)
+                          reverse
+                          (interpose "children"))]
+    (apply io/file root components)))
+
+(defn thing->children [config thing]
+  {:pre [(not (t/leaf? thing))]}
+  (io/file (thing->handle config thing) "children"))
+
+(defn thing->meta-handle [config thing]
+  (io/file (thing->handle config) "meta.edn"))
+
+(defn thing->related-handle [config thing]
+  (io/file (thing->children config (:parent thing)) "related.edn"))
+
+(defn thing->examples-handle [config thing]
+  (io/file (thing->children config thing) "examples"))
+
+(defn thing->notes-handle [config thing]
+  (io/file (thing->children config thing) "notes"))

--- a/src/grimoire/api/fs2/read.clj
+++ b/src/grimoire/api/fs2/read.clj
@@ -1,0 +1,216 @@
+(ns grimoire.api.fs2.read
+  "Filesystem v2 datastore implementation of the Grimoire API."
+  (:refer-clojure :exclude [isa?])
+  (:require [grimoire.things :as t]
+            [grimoire.api :as api]
+            [grimoire.util :as util
+             :refer [normalize-version]]
+            [grimoire.either :refer [succeed result fail succeed?]]
+            [grimoire.api.fs2 :as fs]
+            [grimoire.api.fs2.impl :as impl]
+            [clojure.java.io :as io]
+            [clojure.string :as string]
+            [cemerick.url :as url])
+  (:import [java.io File]))
+
+(defn- f->name [^File f]
+  (url/url-decode (.getName f)))
+
+;; List things
+;;--------------------
+(defmethod api/-list-groups ::fs/Config [config]
+  (let [handle (io/file (:docs config))]
+    (if (.isDirectory handle)
+      (succeed
+       (for [d     (.listFiles handle)
+             :when (.isDirectory d)
+             :when (.exists (io/file d "meta.edn"))]
+         (t/->Group (url/url-decode (f->name d)))))
+      (fail "Could not find store directory"))))
+
+(defmethod api/-list-artifacts ::fs/Config [config thing]
+  (let [thing  (t/ensure-thing thing)
+        thing  (t/thing->group thing)
+        _      (assert thing)
+        handle (impl/thing->handle config :else thing)]
+    (if (.isDirectory handle)
+      (succeed
+       (for [d     (.listFiles handle)
+             :when (.isDirectory d)]
+         (t/->Artifact thing (f->name d))))
+      (->> thing
+           t/thing->path
+           (str "No such group ")
+           fail))))
+
+(defmethod api/-list-versions ::fs/Config [config thing]
+  (let [thing    (t/ensure-thing thing)
+        artifact (t/thing->artifact thing)
+        _        (assert artifact)
+        handle   (impl/thing->handle config :else artifact)]
+    (if (.isDirectory handle)
+      (->> (for [d     (reverse (sort (.listFiles handle)))
+                 :when (.isDirectory d)]
+             (t/->Version artifact (f->name d)))
+           (sort-by (comp util/clojure-version->cmp-key t/thing->name))
+           reverse
+           succeed)
+      (fail (str "No such artifact "
+                 (t/thing->path thing))))))
+
+(defmethod api/-list-platforms ::fs/Config [config thing]
+  (let [thing   (t/ensure-thing thing)
+        _       (assert thing)
+        version (t/thing->version thing)
+        _       (assert version)
+        handle  (impl/thing->handle config :else version)]
+    (if (.isDirectory handle)
+      (succeed
+       (for [d     (sort-by #(f->name %) (.listFiles handle))
+             :when (.isDirectory d)]
+         (t/->Platform version (f->name d))))
+      (fail (str "No such version "
+                 (t/thing->path thing))))))
+
+(defmethod api/-list-namespaces ::fs/Config [config thing]
+  (let [thing    (t/ensure-thing thing)
+        _        (assert thing)
+        platform (t/thing->platform thing)
+        _        (assert platform)
+        handle   (impl/thing->handle config :else platform)]
+    (if (.isDirectory handle)
+      (succeed
+       (for [d     (.listFiles handle)
+             :when (.isDirectory d)]
+         (t/->Ns platform (f->name d))))
+      (fail (str "No such platform "
+                 (t/thing->path thing))))))
+
+(defmethod api/-list-defs ::fs/Config [config thing]
+  (let [thing     (t/ensure-thing thing)
+        _         (assert thing)
+        namespace (t/thing->namespace thing)
+        _         (assert namespace)
+        handle    (impl/thing->handle config :else namespace)]
+    (if (.isDirectory handle)
+      (succeed
+       (for [d     (.listFiles handle)
+             :when (.isDirectory d)]
+         (t/->Def namespace (f->name d))))
+      (fail (str "No such namespace "
+                 (t/thing->path thing))))))
+
+(defmethod api/-list-notes ::fs/Config [config thing]
+  {:pre [(t/thing? thing)]}
+  (let [lhs (.toPath (io/file (:notes config)))]
+    (if (t/versioned? thing)
+      (let [versions (api/thing->prior-versions config thing)]
+        (if (succeed? versions)
+          (succeed
+           (for [prior-thing (result versions)
+                 :let        [v (t/thing->name (t/thing->version prior-thing))
+                              h (impl/thing->notes-handle config prior-thing)]
+                 :when       (and (.exists h)
+                                  (.isDirectory h))]
+             (let [rhs (.toPath h)
+                   p   (.relativize lhs rhs)]
+               (-> thing
+                   (t/->Note (.getName h)
+                             (.getPath h))
+                   (assoc ::t/file (.toString p))))))
+
+          ;; versions is a Fail, pass it down
+          versions))
+
+      (let [^File h (impl/thing->notes-handle config thing)]
+        (if (.exists h)
+          (let [rhs (.toPath h)
+                p   (.relativize lhs rhs)]
+            (succeed [(-> thing
+                          (t/->Note (.getName h), (.getPath h))
+                          (assoc ::t/file (.toString p)))]))
+          (fail "No notes file!"))))))
+
+(defmethod api/-list-examples ::fs/Config [config thing]
+  {:pre [(t/thing? thing)]}
+  (let [versions (api/thing->prior-versions config thing)
+        lhs      (.toPath (io/file (:notes config)))]
+    (if (succeed? versions)
+      (succeed
+       (for [prior-thing (result versions)
+             :let        [v (t/thing->name (t/thing->version prior-thing))
+                          h (impl/thing->examples-handle config prior-thing)]
+             :when       (and (.exists h)
+                              (.isDirectory h))
+             ex          (.listFiles h)
+             :when       (.isFile ex)
+             :when       (not (.startsWith (.getName ex) "."))]
+         (let [rhs (.toPath ex)
+               p   (.relativize lhs rhs)]
+           (-> thing
+               (t/->Example (.getName ex)
+                            (.getPath ex))
+               (assoc ::t/file (.toString p))))))
+
+      ;; versions is a Fail, pass it down
+      versions)))
+
+;; Read things
+;;--------------------
+
+(defmethod api/-read-note ::fs/Config [config thing]
+  {:pre [(t/note? thing)]}
+  (let [handle (io/file (t/thing->path thing))]
+    (if (.exists handle) ;; guard against missing files
+      (-> handle slurp succeed)
+      (fail (str "No note for object "
+                 (t/thing->path (t/thing->parent thing)))))))
+
+(defmethod api/-read-example ::fs/Config [config thing]
+  {:pre [(t/example? thing)]}
+  (let [handle (io/file (:handle thing))]
+    (if (.exists handle) ;; guard against missing files
+      (-> handle slurp succeed)
+      (fail (str "No such example! "
+                 (:handle thing))))))
+
+(defmethod api/-read-meta ::fs/Config [config thing]
+  (let [thing  (t/ensure-thing thing)
+        handle (impl/thing->meta-handle config thing)]
+    (if (.exists handle) ;; guard against missing files
+      (-> handle
+          slurp
+          (string/replace #"#<.*?>" "nil") ;; FIXME: Hack to ignore unreadable #<>s
+          util/edn-read-string-with-readers
+          succeed)
+      (fail (str "No meta for object "
+                 (t/thing->path thing))))))
+
+(defmethod api/-list-related ::fs/Config [config thing]
+  ;; FIXME: This assumes the old Grimoire 0.3.X related file format,
+  ;; being a sequence of fully qualified symbols not Thing URIs. Will
+  ;; work, but not optimal in terms of utility going forwards.
+  ;;
+  ;; As there are no datafiles which use this "related" format, it's
+  ;; questionable whether preserving this format is a good idea or
+  ;; not. I'm somewhat inclined to say not, but it's not high
+  ;; priority.
+
+  (let [thing           (t/ensure-thing thing)
+        current-version (t/thing->version thing)
+        versions        (api/thing->prior-versions config thing)]
+    (if (succeed? versions)
+      (succeed
+       (for [thing (result versions)
+             :let  [v (t/thing->name (t/thing->version thing))
+                    h (impl/thing->related-handle config thing)]
+             :when (.exists h)
+             :when (.isFile h)
+             line  (line-seq (io/reader h))
+             :let  [sym (read-string line)]]
+         (-> current-version
+             (t/->Ns  (namespace sym))
+             (t/->Def (name sym)))))
+
+      ;; versions is a Fail, pass it down
+      versions)))

--- a/src/grimoire/api/fs2/write.clj
+++ b/src/grimoire/api/fs2/write.clj
@@ -1,0 +1,59 @@
+(ns grimoire.api.fs2.write
+  "Filesystem v2 datastore implementation of the Grimoire API."
+  (:refer-clojure :exclude [isa?])
+  (:require [grimoire.things :as t]
+            [grimoire.api :as api]
+            [grimoire.api.fs2 :as fs]
+            [grimoire.api.fs2.impl :as impl]))
+
+;; Interacting with the datastore - writing
+;;--------------------------------------------------------------------
+(defmethod api/-write-meta ::fs/Config [config thing data]
+  {:pre [(fs/Config? config)
+         (t/thing? thing)
+         (map? data)]}
+  (let [thing  (t/ensure-thing thing)
+        _      (assert thing)
+        handle (impl/thing->meta-handle config thing)
+        _      (assert handle)]
+    (.mkdirs (.getParentFile handle))
+    (spit handle (pr-str data))
+    nil))
+
+(defmethod api/-write-note ::fs/Config [config thing data]
+  {:pre [(fs/Config? config)
+         (t/thing? thing)
+         (string? data)]}
+  (let [thing  (t/ensure-thing thing)
+        _      (assert thing)
+        handle (impl/thing->notes-handle config thing)
+        _      (assert thing)]
+    (.mkdirs (.getParentFile handle))
+    (spit handle data)))
+
+(defmethod api/-write-example ::fs/Config [config thing data]
+  {:pre [(fs/Config? config)
+         (t/thing? thing)
+         (string? data)]}
+  (let [thing  (t/ensure-thing thing)
+        _      (assert thing)
+        id     (java.util.UUID/randomUUID)
+        handle (impl/thing->example-handle config thing id)
+        _      (assert thing)]
+    (.mkdirs (.getParentFile handle))
+    (spit handle data)))
+
+
+(defmethod api/-write-related ::fs/Config [config thing related-things]
+  {:pre [(fs/Config? config)
+         (t/thing? thing)
+         (every? t/thing? related-things)]}
+  (let [thing  (t/ensure-thing thing)
+        _      (assert thing)
+        _      (assert (t/def? thing))
+        handle (impl/thing->related-handle config thing)
+        _      (assert thing)]
+    (.mkdirs (.getParentFile handle))
+    (doseq [thing related-things]
+      (spit handle (str (t/thing->path thing) \newline)
+            :append true))))

--- a/src/grimoire/things.clj
+++ b/src/grimoire/things.clj
@@ -3,8 +3,9 @@
   uniquely naming and referencing entities in a Grimoire documentation
   store.
 
-  Thing     ::= Sum[Group, Artifact, Version, Platform,
-                    Namespace, Def, Note, Example];
+  ```
+  Thing ::= Sum[Group, Artifact, Version, Platform,
+                Namespace, Def, Note, Example];
   Group     ::= Record[                   Name: String];
   Artifact  ::= Record[Parent: Group,     Name: String];
   Version   ::= Record[Parent: Artifact,  Name: String];
@@ -13,7 +14,9 @@
   Def       ::= Record[Parent: Namespace, Name: String];
 
   Note      ::= Record[Parent: Thing,     Handle: String];
-  Example   ::= Record[Parent: Thing,     Handle: String];"
+  Example   ::= Record[Parent: Thing,     Handle: String];
+  ```
+  "
   (:refer-clojure :exclude [def namespace])
   (:require [clojure.string :as string]
             [clojure.core.match :refer [match]]
@@ -441,3 +444,12 @@
       (if ?def
         [:def nil nil nil platform ns ?def]
         [:ns  nil nil nil platform ns]))))
+
+(defn thing->pattern [t]
+  (->> t
+       (iterate :parent)
+       (take-while (complement nil?))
+       (map :name)
+       reverse
+       (cons (keyword (name (t/tag t))))
+       vec))

--- a/src/grimoire/util.clj
+++ b/src/grimoire/util.clj
@@ -90,7 +90,11 @@
   installed.
 
   Currently the only additional reader function is the default reader function,
-  which will return a tuple [:cant-read <tag symbol> <raw value>]."
+  which will return a tuple [::unreadable <tag symbol> <raw value>]."
   [s]
-  (edn/read-string {:default (fn [t v] [:cant-read t v])}
+  (edn/read-string {:default (fn [t v] [::unreadable t v])}
                    s))
+
+(defn file?
+  [h]
+  (instance? java.io.File h))


### PR DESCRIPTION
The goal of this changeset is to implement a v2 filesystem driver which makes fewer dumb assumptions about the precise structure of the backing filesystem store. Particularly, it tries to support multiple notes, examples and other future leaf structures an examples on arbitrary things well.

This work is mainly designed to support Stacks and clj-doc.