### PR TITLE
replace version compare stuff with version-clj impl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "bin/hooks"]
-	path = bin/hooks
-	url = git@github.com:arrdem/git-flow-hooks.git

--- a/bin/install-hooks.sh
+++ b/bin/install-hooks.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-rm -r ./.git/hooks
-ln -s ../bin/hooks .git/hooks

--- a/deps.edn
+++ b/deps.edn
@@ -3,4 +3,4 @@
         me.arrdem/guten-tag {:mvn/version  "0.1.6" :exclusions [org.clojure/clojure]}
         version-clj {:mvn/version "0.1.2"}
         org.clojure/core.match {:mvn/version "0.3.0-alpha4" :exclusions [org.clojure/clojure]}
-        com.cemerick/url {:mvn/version "0.1.1" :exclusions [com.cemerick/clojurescript.test org.clojure/clojure]}}
+        com.cemerick/url {:mvn/version "0.1.1" :exclusions [com.cemerick/clojurescript.test org.clojure/clojure]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.9.0"}
+        me.arrdem/guten-tag {:mvn/version  "0.1.6" :exclusions [org.clojure/clojure]}
+        version-clj {:mvn/version "0.1.2"}
+        org.clojure/core.match {:mvn/version "0.3.0-alpha4" :exclusions [org.clojure/clojure]}
+        com.cemerick/url {:mvn/version "0.1.1" :exclusions [com.cemerick/clojurescript.test org.clojure/clojure]}}

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [me.arrdem/guten-tag "0.1.6"
                   :exclusions [org.clojure/clojure]]
+                 [version-clj "0.1.2"]
                  [org.clojure/core.match "0.3.0-alpha4"
                   :exclusions [org.clojure/clojure]]
                  [com.cemerick/url "0.1.1"

--- a/src/grimoire/api/fs/read.clj
+++ b/src/grimoire/api/fs/read.clj
@@ -10,7 +10,8 @@
             [grimoire.api.fs.impl :as impl]
             [clojure.java.io :as io]
             [clojure.string :as string]
-            [cemerick.url :as url])
+            [cemerick.url :as url]
+            [version-clj.core :as v])
   (:import [java.io File]))
 
 (defn- f->name [^File f]
@@ -52,7 +53,7 @@
       (->> (for [d     (reverse (sort (.listFiles handle)))
                  :when (.isDirectory d)]
              (t/->Version artifact (f->name d)))
-           (sort-by (comp util/clojure-version->cmp-key t/thing->name))
+           (sort-by t/thing->name v/version-compare)
            reverse
            succeed)
       (fail (str "No such artifact "


### PR DESCRIPTION
Still had issues (NPEs) with some more exotic version strings. They got fixed by just using `version-clj`. 